### PR TITLE
Add support for newer parameters: selected-value, use-repository

### DIFF
--- a/jjb_git_parameter/git.py
+++ b/jjb_git_parameter/git.py
@@ -31,7 +31,9 @@ def git_parameter(parser, xml_parent, data):
             ('tag-filter', 'tagFilter'),
             ('sort-mode', 'sortMode'),
             ('default-value', 'defaultValue'),
-            ('quick-filter', 'quickFilterEnabled')
+            ('quick-filter', 'quickFilterEnabled'),
+            ('selected-value', 'selectedValue'),
+            ('use-repository', 'useRepository')
    ):
      value = data.get(opt, '')
      if isinstance(notifier, str):


### PR DESCRIPTION
Added two new parameters supported in the newer versions of the plugin:
selected-value - goes hand-in-hand with default-value
use-repository - specify the git repo to apply parameters to when using multi-scm.